### PR TITLE
Fix printf %zu and 0x%p

### DIFF
--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -14,8 +14,8 @@
 
 void memarray_init(memarray_t *mem, void *data, size_t size, size_t num)
 {
-    DEBUG("memarray: Initialize memarray of %zu times %zu Bytes at %p\n",
-          num, size, data);
+    DEBUG("memarray: Initialize memarray of %u times %u Bytes at %p\n",
+          (unsigned)num, (unsigned)size, data);
 
     mem->free_data = data;
     mem->size = size;
@@ -34,7 +34,7 @@ void *memarray_alloc(memarray_t *mem)
     }
     void *free = mem->free_data;
     mem->free_data = *((void **)mem->free_data);
-    DEBUG("memarray: Allocate %zu Bytes at %p\n", mem->size, free);
+    DEBUG("memarray: Allocate %u Bytes at %p\n", (unsigned)mem->size, free);
     return free;
 }
 
@@ -42,5 +42,5 @@ void memarray_free(memarray_t *mem, void *ptr)
 {
     memcpy(ptr, &mem->free_data, sizeof(void *));
     mem->free_data = ptr;
-    DEBUG("memarray: Free %zu Bytes at %p\n", mem->size, ptr);
+    DEBUG("memarray: Free %u Bytes at %p\n", (unsigned)mem->size, ptr);
 }

--- a/tests/memarray/main.c
+++ b/tests/memarray/main.c
@@ -57,9 +57,9 @@ void fill_memory(struct block_t *head)
         head->message[MESSAGE_SIZE - 1] = 0;
         head->number = aux;
 
-        printf("\t(%i, %s) Allocated %zu Bytes at 0x%p, total %d\n",
-               head->number, head->message, sizeof(struct block_t), (void *)head,
-               total);
+        printf("\t(%i, %s) Allocated %u Bytes at %p, total %d\n",
+               head->number, head->message, (unsigned)sizeof(struct block_t),
+               (void *)head, total);
 
         /* NOTE: If there is not space, memarray_alloc returns zero */
         head->next = memarray_alloc(&block_storage);
@@ -76,8 +76,9 @@ void free_memory(struct block_t *head)
 
     while (head) {
         total -= sizeof(struct block_t);
-        printf("\tFree (%i) %zu Bytes at 0x%p, total %d\n", \
-               head->number, sizeof(struct block_t), (void *)head, total);
+        printf("\tFree (%i) %u Bytes at %p, total %d\n", \
+               head->number, (unsigned)sizeof(struct block_t),
+               (void *)head, total);
 
         if (head->next) {
             old = head;


### PR DESCRIPTION
I tested on iotlab-m3 and wsn430-v1_3b the test works.

There are just some issues when printing on stm32 and wsn430 nodes as %zu is not implemented. We usually cast it to (unsigned) and use %u.
Also for pointers, it prints 0x0x12345. Feel free to squash my commits later.